### PR TITLE
Fix link to edit the post

### DIFF
--- a/content/articles/open-your-source-as-if-you-gonna-die-tonight.md
+++ b/content/articles/open-your-source-as-if-you-gonna-die-tonight.md
@@ -7,7 +7,7 @@ status: published
 Summary: You should open-source as-if you gonna die tonight. Literally.
 
 ***[ To keep the spirit of this post honest, I am going to publish this blog, immidiately. No __draft__-ing. This post will be, I hope, under continuous improvement.  
-This post is [available for edit on GitHub](https://github.com/kmonsoor/blog.kmonsoor.com/edit/master/content/articles/tech/open-your-source-as-if-you-gonna-die-tonight.md), currently in its version 0.0.6 ]***
+This post is [available for edit on GitHub](https://github.com/kmonsoor/blog.kmonsoor.com/edit/live/content/articles/open-your-source-as-if-you-gonna-die-tonight.md), currently in its version 0.0.6 ]***
 
 
 


### PR DESCRIPTION
Just a simple fix. I imagine GitHub has changed their link system since you wrote this. ;)

In addition, you might want to consider fixing the spelling on "immidiately" to "immediately"  and maybe "draft-ing" to "drafting" (probably more optional).

Anyway, I like your post! 